### PR TITLE
Add executables declaration to gemspec

### DIFF
--- a/lutaml-xsd.gemspec
+++ b/lutaml-xsd.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.bindir = "exe"
   spec.require_paths = ["lib"]
+  spec.executables = ["lutaml-xsd"]
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
@@ -31,7 +32,7 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency "liquid", "~> 5.0"
-  spec.add_dependency "lutaml-model", "~> 0.8"
+  spec.add_dependency "lutaml-model", "~> 0.8.0"
   spec.add_dependency "moxml"
   spec.add_dependency "paint", "~> 2.3"
   spec.add_dependency "rubyzip", "~> 2.3"


### PR DESCRIPTION
## Summary
- Add missing `spec.executables = ["lutaml-xsd"]` to gemspec
- Without this, the `lutaml-xsd` CLI is not symlinked to the user's bin path when the gem is installed

## Test plan
- [ ] Build and install the gem, verify `lutaml-xsd` command is available in PATH