### PR TITLE
Fix release workflow: build frontend before gem build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
     uses: metanorma/ci/.github/workflows/rubygems-release.yml@main
     with:
       next_version: ${{ github.event.inputs.next_version }}
+      post_install: 'cd frontend && npm install && npm run build'
     secrets:
       rubygems-api-key: ${{ secrets.LUTAML_CI_RUBYGEMS_API_KEY }}
       pat_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The CI reusable workflow (metanorma/ci) has two release paths:
- **API Key path**: uses `bundle exec rake release` (builds frontend via Rakefile hook)
- **OIDC path**: uses `gem build *.gemspec` directly (**NO frontend build**)

The OIDC path was being used, so published gems had no frontend assets.

Fix: use the `post_install` input to build frontend assets before either release path executes. This ensures `frontend/dist/` exists when `gem build` runs, so `Dir.glob` in the gemspec picks up the files.