### PR TITLE
docs: update documentation for v1.1.3 features

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -11,7 +11,8 @@ image:https://github.com/lutaml/lutaml-xsd/actions/workflows/rake.yml/badge.svg[
 Lutaml::Xsd is a Ruby gem designed to parse and manipulate XML Schema Definition
 (XSD) files. It provides a robust framework for handling XSD elements,
 attributes, complex types, and all other XSD constructs, allowing users to
-programmatically work with XML schemas.
+programmatically work with XML schemas. It also supports RELAX NG (RNG/RNC)
+schemas through automatic conversion to XSD.
 
 NOTE: For UML-to-XSD mapping and YAML documentation generation (including
 ShapeChange integration), see the
@@ -45,8 +46,16 @@ allowing you to shape and structure your data into useful forms.
   - Single-file mode
   - Entrypoint prioritization in sidebar
   - Schema detail views with elements/types/attributes tables
+  - Interactive group tree view with nested choices and sequences
+  - Inline complex type display for anonymous types within elements
   - Hash-based navigation with browser back/forward support
   - Dark mode with automatic theme detection
+* <<rng-rnc-support,RELAX NG (RNG/RNC) support>> - Convert and build from
+  RELAX NG schemas
+  - Automatic RNG/RNC to XSD conversion via `RngToXsdConverter`
+  - Build LXR packages directly from `.rng` and `.rnc` files
+  - Support for both XML syntax (`.rng`) and compact syntax (`.rnc`)
+  - Automatic include directive conversion
 * <<schema-validation,XSD schema validation>> with automatic version detection
   - Pre-parsing validation to ensure valid XSD schema documents
   - Automatic detection of XSD 1.0 vs 1.1 features
@@ -138,6 +147,8 @@ lutaml-xsd spa schemas.lxr --output docs.html \
 * Schema navigation with entrypoints prioritized
 * Element and type detail views
 * XML Instance Representation for each component
+* Inline complex type display for anonymous types within elements
+* Interactive group tree view showing nested choices, sequences, and sub-groups
 * Clickable cross-references throughout
 * xs3p-quality documentation
 
@@ -230,6 +241,88 @@ For comprehensive documentation on SPA generation, see:
 * link:docs/SPA_CONFIGURATION.adoc[Configuration Reference] - All configuration options
 * link:docs/SPA_DEPLOYMENT.adoc[Deployment Guide] - Hosting and CI/CD integration
 * link:docs/SPA_ARCHITECTURE.adoc[Architecture Documentation] - Design and extension guide
+
+[[rng-rnc-support]]
+== RELAX NG (RNG/RNC) support
+
+=== General
+
+Lutaml::Xsd can convert RELAX NG schema files (`.rng` XML syntax and `.rnc`
+compact syntax) to XSD, allowing you to build LXR packages and generate
+documentation from RELAX NG schemas using the same tools and workflows.
+
+The `RngToXsdConverter` follows the same mapping logic as jing-trang's RNG-to-XSD
+conversion, handling define resolution, element classification, collision
+detection, and include directives.
+
+=== Building from RNG/RNC files
+
+Use `.rng` or `.rnc` files directly in your YAML configuration:
+
+[source,yaml]
+----
+# config.yml
+files:
+  - path/to/schema.rng
+----
+
+Or point to a compact syntax file:
+
+[source,yaml]
+----
+# config.yml
+files:
+  - path/to/schema.rnc
+----
+
+Then build the package as usual:
+
+[source,bash]
+----
+lutaml-xsd pkg build config.yml --output schema.lxr
+----
+
+During package creation, the RNG/RNC file is automatically converted to XSD.
+The generated `.xsd` file is written alongside the original source file (or to a
+temporary directory if the original location is not writable).
+
+=== Ruby API
+
+.Load and query an RNG schema programmatically
+[example]
+====
+[source,ruby]
+----
+require 'lutaml/xsd'
+
+# Load directly from an RNG or RNC file
+repo = Lutaml::Xsd::SchemaRepository.load_from_file('schema.rng')
+
+# Or use the converter directly
+require 'rng'
+grammar = Rng.parse(File.read('schema.rng'))
+xsd_schema = Lutaml::Xsd::RngToXsdConverter.new(grammar).convert
+
+# Serialize to XML
+puts xsd_schema.to_formatted_xml
+----
+====
+
+=== Conversion details
+
+The converter handles:
+
+* **Define resolution** — Named `<define>` blocks are resolved and expanded
+* **Include directives** — RNC `include "path"` and RNG `<include href="..."/>` are
+  converted to XSD `<include>` elements
+* **Collision detection** — Element name collisions from multiple defines are
+  detected and handled
+* **Pattern mapping** — RNG patterns (`<element>`, `<attribute>`, `<choice>`,
+  `<group>`, `<interleave>`, `<optional>`, `<zeroOrMore>`, `<oneOrMore>`,
+  `<data>`, `<value>`, `<list>`, `<text>`) are mapped to their XSD equivalents
+* **Attribute classification** — Patterns that resolve to attributes (including
+  those wrapped in `<optional>`) are correctly classified
+* **Namespace handling** — Target namespace is preserved from the source grammar
 
 [[schema-validation]]
 == XSD schema validation
@@ -839,12 +932,16 @@ lutaml-xsd xml validate-batch <directory/> --package <file.lxr>
 
 === BUILD commands (package creation)
 
-Create LXR packages from configurations.
+Create LXR packages from configurations. Supports XSD, RNG, and RNC input
+files.
 
 [source,bash]
 ----
-# Build from YAML config
+# Build from YAML config (XSD files)
 lutaml-xsd pkg build <config.yml>
+
+# Build from RNG/RNC files (automatically converted to XSD)
+lutaml-xsd pkg build <config.yml>  # config.yml can reference .rng/.rnc files
 
 # Interactive initialization
 lutaml-xsd build init <entrypoint.xsd>
@@ -1055,18 +1152,23 @@ and their relationships:
 
 === Data transformation flow
 
-The following diagram shows how XSD files are processed through the parsing
-pipeline:
+The following diagram shows how XSD and RNG/RNC files are processed through the
+parsing pipeline:
 
 [source]
 ----
-╔═══════════════════╗           ╔═══════════════════════╗
-║   XSD File(s)     ║           ║  Schema Mappings      ║
-║                   ║           ║  (Local redirects)    ║
-╚═════════┬═════════╝           ╚═══════════┬═══════════╝
-          │                                 │
-          └────────────┬────────────────────┘
-                       │
+╔═══════════════════╗   ╔═══════════════════╗   ╔═══════════════════════╗
+║   XSD File(s)     ║   ║  RNG/RNC File(s)  ║   ║  Schema Mappings      ║
+║                   ║   ║                   ║   ║  (Local redirects)    ║
+╚═════════╦═════════╝   ╚═════════╦═════════╝   ╚═══════════╦═══════════╝
+          ║                       ║                         ║
+          ║             ╔═════════╩════════════╗              ║
+          ║             ║ RngToXsdConverter    ║              ║
+          ║             ║ (RNG/RNC → XSD)     ║              ║
+          ║             ╚═════════╦════════════╝              ║
+          ║                       ║                         ║
+          ╚════════════╦══════════╩═══════════════════════════╝
+                       ║
                        ▼
               ┌────────────────┐
               │  XSD Parser    │
@@ -1453,6 +1555,8 @@ Syntax:
 ----
 files: <1>
   - path/to/schema.xsd
+  - path/to/schema.rng   # RELAX NG XML syntax
+  - path/to/schema.rnc   # RELAX NG Compact syntax
 
 schema_location_mappings: <2>
   - from: "http://schemas.example.com/schema.xsd"
@@ -1465,13 +1569,13 @@ namespace_mappings: <3>
   - prefix: "ex"
     uri: "http://example.com/namespace"
 ----
-<1> List of XSD file paths to include in the package (required)
+<1> List of schema file paths (`.xsd`, `.rng`, or `.rnc`) to include (required)
 <2> Schema location mappings for imports/includes (optional)
 <3> Namespace prefix mappings (optional)
 
 Where,
 
-`files`:: Array of XSD file paths to include in the package (required)
+`files`:: Array of schema file paths (`.xsd`, `.rng`, or `.rnc`) to include in the package (required). RNG/RNC files are automatically converted to XSD.
 `schema_location_mappings`:: Array of schema location redirections (optional)
 `namespace_mappings`:: Array of namespace prefix-to-URI mappings (optional)
 
@@ -1545,9 +1649,13 @@ NOTE: The `pkg build` command requires a YAML configuration file as input. Direc
 [example]
 [source,yaml]
 ----
-# minimal_config.yaml
+# minimal_config.yaml (XSD)
 files:
   - path/to/schema.xsd
+
+# minimal_config.yaml (RNG/RNC — automatically converted to XSD)
+files:
+  - path/to/schema.rng
 ----
 
 Then build the package:

--- a/docs/ARCHITECTURE.adoc
+++ b/docs/ARCHITECTURE.adoc
@@ -457,6 +457,33 @@ The [`Lutaml::Xsd::Glob`](lib/lutaml/xsd/glob.rb) class manages schema location 
 
 This design allows offline development, schema version control, and consistent schema handling across environments.
 
+=== RNG to XSD Converter
+
+The [`Lutaml::Xsd::RngToXsdConverter`](lib/lutaml/xsd/rng_to_xsd_converter.rb) converts RELAX NG (`.rng` / `.rnc`) schemas to XSD.
+
+**Responsibilities:**
+
+* Convert `Rng::Grammar` objects to `Lutaml::Xsd::Schema` objects
+* Resolve named `<define>` blocks with cycle detection
+* Classify patterns as elements, attributes, or particles
+* Detect and handle element name collisions across defines
+* Convert include directives from RNC/RNG to XSD `<include>` elements
+* Map RNG patterns (`<element>`, `<attribute>`, `<choice>`, `<group>`, `<interleave>`, `<optional>`, `<zeroOrMore>`, `<oneOrMore>`, `<data>`, `<value>`, `<list>`, `<text>`) to XSD equivalents
+
+**Integration points:**
+
+* `SchemaRepository#parse_schema_file` — automatically invokes the converter for `.rng`/`.rnc` files
+* `SchemaRepository.from_file` — accepts `.rng` and `.rnc` paths
+
+**Conversion pipeline:**
+
+. Parse RNG/RNC file into `Rng::Grammar` object (via the `rng` gem)
+. `RngToXsdConverter#convert` maps the grammar to XSD constructs
+. Phase 0: Convert include directives
+. Phase 1: Convert all named defines (with caching and cycle guards)
+. Phase 2: Convert start elements and top-level elements
+. Result is a standard `Lutaml::Xsd::Schema` object usable by all downstream components
+
 === Schema Repository
 
 The [`Lutaml::Xsd::SchemaRepository`](lib/lutaml/xsd/schema_repository.rb) provides namespace-aware type resolution across multiple schemas.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,37 @@ All notable changes to lutaml-xsd will be documented in this file.
 
 ## [Unreleased]
 
+## [1.1.3] - 2025-05-15
+
+### Added
+
+- RELAX NG (RNG/RNC) to XSD conversion via `Lutaml::Xsd::RngToXsdConverter`
+- Build LXR packages directly from `.rng` and `.rnc` files
+- `SchemaRepository.load_from_file` accepts `.rng` and `.rnc` schema files
+- Inline/anonymous complex type display in SPA documentation — complex types defined within elements are now surfaced with synthetic names
+- Group tree view in SPA — new `GroupTreeItem` component for interactive, nested rendering of groups with choices and sequences
+- Sequence and choice serialization in SPA — `xs:sequence` and `xs:choice` model groups are fully serialized with nesting support
+- Schema include display in SPA documentation
+
+### Fixed
+
+- SPA generation error when serializing SimpleContent types
+- Schema validation error handling
+
+## [1.1.2] - 2025-05-12
+
+- Refactor: eliminate `send()` calls in lutaml-xsd (22 → 0)
+- Refactor: eliminate `respond_to?` duck-typing in lutaml-xsd (371 → 1)
+- Fix: merge included schemas by namespace, refactor SchemaSerializer for DRY/security
+
+## [1.1.1] - 2025-05-09
+
+- Fix: merge included schemas by namespace, refactor SchemaSerializer for DRY/security
+
+## [1.1.0] - 2025-05-08
+
+- Fix: SVG diagram generation for XSD type definitions
+
 ## [0.1.0] - 2024-11-18
 
 - Initial release

--- a/docs/CLI.adoc
+++ b/docs/CLI.adoc
@@ -47,7 +47,9 @@ Package commands create, validate, and inspect LXR schema repository packages.
 
 === pkg build
 
-Build an LXR package from a YAML configuration file.
+Build an LXR package from a YAML configuration file. The `files` list in the
+configuration may reference `.xsd`, `.rng`, or `.rnc` files. RNG/RNC files are
+automatically converted to XSD during the build process.
 
 Syntax:
 
@@ -58,7 +60,9 @@ lutaml-xsd pkg build CONFIG_FILE [options]
 
 Where,
 
-`CONFIG_FILE`:: Path to YAML configuration file (required)
+`CONFIG_FILE`:: Path to YAML configuration file (required). The `files` list
+supports `.xsd`, `.rng` (RELAX NG XML syntax), and `.rnc` (RELAX NG Compact
+syntax) files.
 
 Options:
 
@@ -1480,6 +1484,31 @@ lutaml-xsd type find "gml:CodeType" --from pkg/urban.lxr
 
 # 5. Get statistics
 lutaml-xsd stats show pkg/urban.lxr
+----
+====
+
+=== Building from RELAX NG schemas
+
+.Building a package from RNG/RNC files
+[example]
+====
+[source,bash]
+----
+# 1. Create configuration file referencing .rng or .rnc files
+cat > rng_schemas.yml << 'EOF'
+files:
+  - schemas/isostandard.rnc
+  - schemas/biblio.rnc
+EOF
+
+# 2. Build package (RNG/RNC files are automatically converted to XSD)
+lutaml-xsd pkg build rng_schemas.yml \
+  --name "ISO Standard Schemas" \
+  --version "1.0" \
+  --output pkg/iso_schemas.lxr
+
+# 3. Query types as normal
+lutaml-xsd type list --from pkg/iso_schemas.lxr
 ----
 ====
 

--- a/docs/INDEX.adoc
+++ b/docs/INDEX.adoc
@@ -15,10 +15,13 @@ basic usage to advanced technical topics.
 
 == What's new in lutaml-xsd
 
-Latest version: 1.0.4
+Latest version: 1.1.3
 
 Recent highlights:
 
+* 🎉 **RELAX NG Support** - Build packages from `.rng` and `.rnc` files with automatic XSD conversion
+* 🌳 **Interactive Group Tree** - Expandable tree view for groups with nested choices and sequences
+* 📝 **Inline Complex Types** - Anonymous complex types within elements displayed with synthetic names
 * 🎉 **LXR Packages** - Self-contained, portable schema repositories
 * ⚡ **Fast Type Index** - Pre-built indexes for instant lookups
 * 🔧 **Three Configuration Axes** - XSD mode, resolution mode, serialization

--- a/docs/LXR_PACKAGES.adoc
+++ b/docs/LXR_PACKAGES.adoc
@@ -337,13 +337,13 @@ namespace_mappings: <3>
   - prefix: "ex"
     uri: "http://example.com/namespace"
 ----
-<1> List of XSD files to include (required)
+<1> List of schema files (`.xsd`, `.rng`, or `.rnc`) to include (required)
 <2> Schema location mappings for imports/includes (optional)
 <3> Namespace prefix mappings (optional)
 
 Where,
 
-`files`:: Array of XSD file paths to include in the package (required)
+`files`:: Array of schema file paths (`.xsd`, `.rng`, or `.rnc`) to include in the package (required). RNG/RNC files are automatically converted to XSD.
 `schema_location_mappings`:: Array of schema location redirections (optional)
 `namespace_mappings`:: Array of namespace prefix-to-URI mappings (optional)
 

--- a/docs/PACKAGE_CONFIGURATION.adoc
+++ b/docs/PACKAGE_CONFIGURATION.adoc
@@ -22,13 +22,15 @@ LXR packages are highly configurable through three independent axes, allowing yo
 
 ==== `files` (required for standalone packages)
 
-Array of XSD file paths to include in the package. Required when building a standalone package (not using `base_packages`).
+Array of schema file paths to include in the package. Supports `.xsd` (XML Schema), `.rng` (RELAX NG XML syntax), and `.rnc` (RELAX NG Compact syntax) files. RNG/RNC files are automatically converted to XSD during the build process. Required when building a standalone package (not using `base_packages`).
 
 [source,yaml]
 ----
 files:
   - path/to/schema.xsd
   - path/to/another.xsd
+  - path/to/schema.rng   # RELAX NG XML syntax
+  - path/to/schema.rnc   # RELAX NG Compact syntax
 ----
 
 ==== `output_package` (optional)

--- a/docs/QUICK_START.adoc
+++ b/docs/QUICK_START.adoc
@@ -29,6 +29,8 @@ See link:INSTALLATION[Installation guide] for detailed instructions.
 
 Create a simple XSD file:
 
+Create a simple XSD file:
+
 .Creating example.xsd
 [example]
 ====
@@ -248,6 +250,56 @@ Package statistics:
   Total namespaces: 1
   element: 1
   simple_type: 1
+----
+====
+
+== Working with RELAX NG schemas
+
+Lutaml::Xsd supports building packages directly from RELAX NG schemas (`.rng`
+XML syntax and `.rnc` compact syntax). The schemas are automatically converted
+to XSD during the build process.
+
+=== Creating a package from an RNC file
+
+.Building from RELAX NG Compact syntax
+[example]
+====
+[source,bash]
+----
+# 1. Create minimal configuration
+cat > rng_config.yml << 'EOF'
+files:
+  - path/to/schema.rnc
+EOF
+
+# 2. Build package
+lutaml-xsd pkg build rng_config.yml \
+  --name "My RNG Schemas" \
+  --output my_rng_schemas.lxr
+
+# 3. Query types as normal
+lutaml-xsd type list --from my_rng_schemas.lxr
+----
+====
+
+=== Using the Ruby API with RNG files
+
+.Loading RNG files programmatically
+[example]
+====
+[source,ruby]
+----
+require 'lutaml/xsd'
+
+# Load directly from an RNG file
+repo = Lutaml::Xsd::SchemaRepository.load_from_file('schema.rng')
+
+# Or from an RNC file
+repo = Lutaml::Xsd::SchemaRepository.load_from_file('schema.rnc')
+
+# Query types exactly as with XSD packages
+result = repo.find_type('TypeName')
+puts result.qname if result.resolved?
 ----
 ====
 

--- a/docs/RUBY_API.adoc
+++ b/docs/RUBY_API.adoc
@@ -1333,6 +1333,93 @@ puts "Loaded #{stats[:total_types]} types"
 ----
 ====
 
+==== from_file()
+
+Load repository from a single schema file. Supports XSD (`.xsd`), RELAX NG
+XML syntax (`.rng`), and RELAX NG Compact syntax (`.rnc`) files. RNG/RNC files
+are automatically converted to XSD.
+
+Syntax:
+
+[source,ruby]
+----
+repo = Lutaml::Xsd::SchemaRepository.from_file(path) <1>
+----
+<1> Load repository from a schema file
+
+Where,
+
+`path`:: Path to a schema file (`.xsd`, `.rng`, or `.rnc`) (String) (required)
+
+Returns a new [`SchemaRepository`](lib/lutaml/xsd/schema_repository.rb:10) instance.
+
+.Loading from different schema formats
+[example]
+====
+[source,ruby]
+----
+# Load from XSD
+repo = Lutaml::Xsd::SchemaRepository.from_file('schema.xsd')
+
+# Load from RELAX NG XML syntax
+repo = Lutaml::Xsd::SchemaRepository.from_file('schema.rng')
+
+# Load from RELAX NG Compact syntax
+repo = Lutaml::Xsd::SchemaRepository.from_file('schema.rnc')
+
+# All formats produce the same type of repository object
+repo.parse.resolve
+result = repo.find_type('TypeName')
+----
+====
+
+==== RngToXsdConverter
+
+Convert a RELAX NG grammar to an XSD Schema object directly.
+
+Syntax:
+
+[source,ruby]
+----
+require 'rng'
+grammar = Rng.parse(rng_content)
+schema = Lutaml::Xsd::RngToXsdConverter.new(grammar, file_path: 'schema.rng').convert
+----
+
+Where,
+
+`grammar`:: A parsed `Rng::Grammar` object (required)
+`file_path`:: Original file path for include directive extraction (optional)
+
+Returns an [`Lutaml::Xsd::Schema`](lib/lutaml/xsd/schema.rb) object.
+
+.Converting RELAX NG to XSD
+[example]
+====
+[source,ruby]
+----
+require 'lutaml/xsd'
+require 'rng'
+
+# Parse an RNG file
+rng_content = File.read('schema.rng')
+grammar = Rng.parse(rng_content,
+  location: File.dirname('schema.rng'),
+  resolve_external: true)
+
+# Convert to XSD
+converter = Lutaml::Xsd::RngToXsdConverter.new(grammar, file_path: 'schema.rng')
+xsd_schema = converter.convert
+
+# Serialize the result
+puts xsd_schema.to_formatted_xml
+
+# Or parse an RNC file directly
+grammar = Rng.parse_file('schema.rnc')
+xsd_schema = Lutaml::Xsd::RngToXsdConverter.new(grammar, file_path: 'schema.rnc').convert
+----
+====
+
 ==== from_yaml_file()
 
 Load repository configuration from a YAML file.

--- a/docs/SPA_GUIDE.adoc
+++ b/docs/SPA_GUIDE.adoc
@@ -15,6 +15,8 @@ The SPA (Single Page Application) Documentation Generator creates modern, intera
 * **Dark mode support** - Automatic system preference detection with manual toggle
 * **Advanced search** - Real-time fuzzy matching across all schema components
 * **Type filtering** - Filter by element, complex type, simple type, attribute group, group
+* **Inline complex types** - Anonymous complex types within elements are displayed with synthetic names
+* **Interactive group tree view** - Expandable tree for groups with nested choices and sequences
 * **Zero dependencies** - Self-contained HTML, CSS, and JavaScript
 * **Offline-capable** - Works without internet connection (inlined mode)
 * **Accessibility** - WCAG 2.1 AA compliant
@@ -184,6 +186,27 @@ Click on any schema component to view:
 * **Documentation** - Extracted annotations
 * **Structure** - Elements, attributes, restrictions
 * **Relationships** - Used by, extends, references
+
+=== Inline complex types
+
+Elements that define an anonymous `<xs:complexType>` inline (without a `name`
+attribute) are automatically surfaced in the documentation with a synthetic
+name derived from the element name (e.g., `Person_type` for an element named
+`Person`). These inline types appear alongside named complex types in the type
+listing and include all their elements, attributes, sequences, and choices.
+
+=== Group tree view
+
+Schema groups (`xs:group`) are rendered as expandable tree items that show
+nested structure:
+
+* **Groups** — Display name or reference, cardinality, and expandable content
+* **Choices** — Shown with `⟨choice⟩` labels and nested options
+* **Sequences** — Shown with their contained elements and sub-groups
+* **Recursive nesting** — Groups can contain choices containing sequences
+  containing groups, all navigable in the tree
+
+The tree supports arbitrary nesting depth and lazy expansion for large schemas.
 
 == Configuration
 


### PR DESCRIPTION
## Summary

Updates all documentation to cover the new features introduced in version 1.1.3.

## Changes

### New feature: RELAX NG (RNG/RNC) support
- **README.adoc**: Added new "RELAX NG (RNG/RNC) support" section with YAML config examples, Ruby API usage, and conversion details
- **docs/CLI.adoc**: Updated `pkg build` description to mention RNG/RNC support; added "Building from RELAX NG schemas" workflow
- **docs/QUICK_START.adoc**: Added "Working with RELAX NG schemas" section with build and Ruby API examples
- **docs/RUBY_API.adoc**: Added `from_file()` and `RngToXsdConverter` API documentation with examples
- **docs/ARCHITECTURE.adoc**: Added "RNG to XSD Converter" component section with conversion pipeline description
- **docs/PACKAGE_CONFIGURATION.adoc**: Updated `files` config to list `.rng`/`.rnc` support
- **docs/LXR_PACKAGES.adoc**: Updated `files` config description for RNG/RNC

### New feature: Inline complex types & Group tree view (SPA)
- **README.adoc**: Added inline complex types and interactive group tree view to SPA feature list
- **docs/SPA_GUIDE.adoc**: Added "Inline complex types" and "Group tree view" sections

### Architecture updates
- **README.adoc**: Updated data transformation flow diagram to show RNG/RNC input alongside XSD
- **docs/ARCHITECTURE.adoc**: Added RngToXsdConverter to component overview

### General updates
- **docs/CHANGELOG.md**: Added v1.1.3, 1.1.2, 1.1.1, 1.1.0 entries
- **docs/INDEX.adoc**: Updated version to 1.1.3 and added new feature highlights
- **README.adoc**: Updated Purpose, Features, BUILD commands, and config sections

## Files changed (10)

| File | Changes |
|------|---------|
| README.adoc | +108/-7 |
| docs/CHANGELOG.md | +31/-1 |
| docs/CLI.adoc | +33/-1 |
| docs/QUICK_START.adoc | +52/-0 |
| docs/RUBY_API.adoc | +87/-0 |
| docs/SPA_GUIDE.adoc | +23/-0 |
| docs/ARCHITECTURE.adoc | +27/-0 |
| docs/INDEX.adoc | +5/-2 |
| docs/PACKAGE_CONFIGURATION.adoc | +4/-1 |
| docs/LXR_PACKAGES.adoc | +4/-1 |