### PR TITLE
Optimize test suite: ~50x speedup (27min → 31s)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ frontend/index.html
 examples/*/pkg/
 examples/*.html
 examples/archive-old/
+examples/02-urban-function/urban_function_docs.html

--- a/spec/lutaml/xsd/schema_repository_spec.rb
+++ b/spec/lutaml/xsd/schema_repository_spec.rb
@@ -119,166 +119,142 @@ RSpec.describe Lutaml::Xsd::SchemaRepository do
     end
   end
 
-  describe "#resolve" do
-    let(:repository) do
-      described_class.new(
-        files: schema_files,
-        schema_location_mappings: schema_location_mappings,
+  # Shared resolved repository for expensive test groups
+  context "with resolved repository" do
+    before(:context) do
+      @resolved_repo = Lutaml::Xsd::SchemaRepository.new(
+        files: [File.expand_path("../../fixtures/i-ur/urbanObject.xsd", __dir__)],
+        schema_location_mappings: [
+          Lutaml::Xsd::SchemaLocationMapping.new(
+            from: '(?:\.\./)+gml/(.+\.xsd)$',
+            to: File.expand_path('../../fixtures/codesynthesis-gml-3.2.1/gml/\1', __dir__),
+            pattern: true,
+          ),
+          Lutaml::Xsd::SchemaLocationMapping.new(
+            from: '(?:\.\./)+iso/(.+\.xsd)$',
+            to: File.expand_path('../../fixtures/codesynthesis-gml-3.2.1/iso/\1', __dir__),
+            pattern: true,
+          ),
+          Lutaml::Xsd::SchemaLocationMapping.new(
+            from: '(?:\.\./)+xlink/(.+\.xsd)$',
+            to: File.expand_path('../../fixtures/codesynthesis-gml-3.2.1/xlink/\1', __dir__),
+            pattern: true,
+          ),
+        ],
       )
+      @resolved_repo.configure_namespaces({
+                                            "gml" => "http://www.opengis.net/gml/3.2",
+                                            "xs" => "http://www.w3.org/2001/XMLSchema",
+                                            "xlink" => "http://www.w3.org/1999/xlink",
+                                            "uro" => "https://www.geospatial.jp/iur/uro/3.2",
+                                          })
+      @resolved_repo.parse.resolve
     end
 
-    before do
-      repository.configure_namespaces(namespace_mappings)
-      repository.parse
+    describe "#resolve" do
+      let(:repository) { @resolved_repo }
+
+      it "resolves schemas and builds indexes" do
+        result = repository.resolve
+        expect(result).to eq(repository)
+      end
+
+      it "indexes types from parsed schemas" do
+        repository.resolve
+        stats = repository.statistics
+        expect(stats[:total_types]).to be > 0
+      end
+
+      it "extracts namespaces from schemas" do
+        repository.resolve
+        namespaces = repository.all_namespaces
+        expect(namespaces).not_to be_empty
+      end
     end
 
-    it "resolves schemas and builds indexes" do
-      result = repository.resolve
-      expect(result).to eq(repository)
+    describe "#find_type" do
+      let(:repository) { @resolved_repo }
+
+      it "finds types from urbanObject schema" do
+        result = repository.find_type("uro:BuildingDetailsType")
+        expect(result).to be_a(Lutaml::Xsd::TypeResolutionResult)
+      end
+
+      it "returns failure for non-existent types" do
+        result = repository.find_type("gml:NonExistentType")
+        expect(result.resolved?).to be false
+        expect(result.error_message).to include("not found")
+      end
+
+      it "returns failure for unregistered namespace prefixes" do
+        result = repository.find_type("unknown:Type")
+        expect(result.resolved?).to be false
+        expect(result.error_message).to include("not registered")
+      end
+
+      it "handles Clark notation" do
+        result = repository.find_type("{https://www.geospatial.jp/iur/uro/3.2}BuildingDetailsType")
+        expect(result).to be_a(Lutaml::Xsd::TypeResolutionResult)
+      end
     end
 
-    it "indexes types from parsed schemas" do
-      repository.resolve
-      stats = repository.statistics
-      expect(stats[:total_types]).to be > 0
+    describe "#validate" do
+      it "validates successfully with correct configuration" do
+        errors = @resolved_repo.validate
+        expect(errors).to be_an(Array)
+      end
+
+      it "detects missing schema files" do
+        bad_repository = described_class.new(files: ["/nonexistent/file.xsd"])
+        errors = bad_repository.validate
+        expect(errors).not_to be_empty
+        expect(errors.first).to include("not found")
+      end
+
+      it "validates namespace mappings" do
+        bad_repository = described_class.new(files: schema_files)
+        bad_repository.instance_variable_set(:@namespace_mappings, [
+                                               Lutaml::Xsd::NamespaceMapping.new(prefix: "", uri: "http://example.com"),
+                                             ])
+        errors = bad_repository.validate
+        expect(errors).not_to be_empty
+      end
     end
 
-    it "extracts namespaces from schemas" do
-      repository.resolve
-      namespaces = repository.all_namespaces
-      expect(namespaces).not_to be_empty
-    end
-  end
+    describe "#statistics" do
+      let(:repository) { @resolved_repo }
 
-  describe "#find_type" do
-    let(:repository) do
-      described_class.new(
-        files: schema_files,
-        schema_location_mappings: schema_location_mappings,
-      )
-    end
+      it "returns repository statistics" do
+        stats = repository.statistics
+        expect(stats).to be_a(Hash)
+        expect(stats).to have_key(:total_schemas)
+        expect(stats).to have_key(:total_types)
+        expect(stats).to have_key(:types_by_category)
+        expect(stats).to have_key(:total_namespaces)
+        expect(stats).to have_key(:namespace_prefixes)
+        expect(stats).to have_key(:resolved)
+        expect(stats).to have_key(:validated)
+      end
 
-    before do
-      repository.configure_namespaces(namespace_mappings)
-      repository.parse
-      repository.resolve
-    end
+      it "reports correct schema count" do
+        stats = repository.statistics
+        expect(stats[:total_schemas]).to be >= 1
+      end
 
-    it "finds types from urbanObject schema" do
-      # urbanObject.xsd defines types in the uro namespace
-      result = repository.find_type("uro:BuildingDetailsType")
-      expect(result).to be_a(Lutaml::Xsd::TypeResolutionResult)
-    end
-
-    it "returns failure for non-existent types" do
-      result = repository.find_type("gml:NonExistentType")
-      expect(result.resolved?).to be false
-      expect(result.error_message).to include("not found")
+      it "reports types by category" do
+        stats = repository.statistics
+        expect(stats[:types_by_category]).to be_a(Hash)
+      end
     end
 
-    it "returns failure for unregistered namespace prefixes" do
-      result = repository.find_type("unknown:Type")
-      expect(result.resolved?).to be false
-      expect(result.error_message).to include("not registered")
-    end
+    describe "#all_namespaces" do
+      let(:repository) { @resolved_repo }
 
-    it "handles Clark notation" do
-      result = repository.find_type("{https://www.geospatial.jp/iur/uro/3.2}BuildingDetailsType")
-      # May or may not be resolved depending on schema content
-      expect(result).to be_a(Lutaml::Xsd::TypeResolutionResult)
-    end
-  end
-
-  describe "#validate" do
-    let(:repository) do
-      described_class.new(
-        files: schema_files,
-        schema_location_mappings: schema_location_mappings,
-      )
-    end
-
-    before do
-      repository.configure_namespaces(namespace_mappings)
-      repository.parse
-    end
-
-    it "validates successfully with correct configuration" do
-      errors = repository.validate
-      expect(errors).to be_an(Array)
-    end
-
-    it "detects missing schema files" do
-      bad_repository = described_class.new(files: ["/nonexistent/file.xsd"])
-      errors = bad_repository.validate
-      expect(errors).not_to be_empty
-      expect(errors.first).to include("not found")
-    end
-
-    it "validates namespace mappings" do
-      bad_repository = described_class.new(files: schema_files)
-      bad_repository.instance_variable_set(:@namespace_mappings, [
-                                             Lutaml::Xsd::NamespaceMapping.new(prefix: "", uri: "http://example.com"),
-                                           ])
-      errors = bad_repository.validate
-      expect(errors).not_to be_empty
-    end
-  end
-
-  describe "#statistics" do
-    let(:repository) do
-      described_class.new(
-        files: schema_files,
-        schema_location_mappings: schema_location_mappings,
-      )
-    end
-
-    before do
-      repository.configure_namespaces(namespace_mappings)
-      repository.parse
-      repository.resolve
-    end
-
-    it "returns repository statistics" do
-      stats = repository.statistics
-      expect(stats).to be_a(Hash)
-      expect(stats).to have_key(:total_schemas)
-      expect(stats).to have_key(:total_types)
-      expect(stats).to have_key(:types_by_category)
-      expect(stats).to have_key(:total_namespaces)
-      expect(stats).to have_key(:namespace_prefixes)
-      expect(stats).to have_key(:resolved)
-      expect(stats).to have_key(:validated)
-    end
-
-    it "reports correct schema count" do
-      stats = repository.statistics
-      expect(stats[:total_schemas]).to be >= 1
-    end
-
-    it "reports types by category" do
-      stats = repository.statistics
-      expect(stats[:types_by_category]).to be_a(Hash)
-    end
-  end
-
-  describe "#all_namespaces" do
-    let(:repository) do
-      described_class.new(
-        files: schema_files,
-        schema_location_mappings: schema_location_mappings,
-      )
-    end
-
-    before do
-      repository.configure_namespaces(namespace_mappings)
-      repository.parse
-      repository.resolve
-    end
-
-    it "returns all registered namespace URIs" do
-      namespaces = repository.all_namespaces
-      expect(namespaces).to be_an(Array)
-      expect(namespaces).not_to be_empty
+      it "returns all registered namespace URIs" do
+        namespaces = repository.all_namespaces
+        expect(namespaces).to be_an(Array)
+        expect(namespaces).not_to be_empty
+      end
     end
   end
 
@@ -325,7 +301,6 @@ RSpec.describe Lutaml::Xsd::SchemaRepository do
         file.rewind
 
         repository = Lutaml::Xsd::SchemaRepository.from_yaml_file(file.path)
-        # The repository is created from the config, verify it exists
         expect(repository).to be_a(Lutaml::Xsd::SchemaRepository)
         expect(repository.files).to include(schema_files.first)
       end
@@ -344,7 +319,6 @@ RSpec.describe Lutaml::Xsd::SchemaRepository do
         file.rewind
 
         repository = Lutaml::Xsd::SchemaRepository.from_yaml_file(file.path)
-        # Should still create repository successfully
         expect(repository).to be_a(Lutaml::Xsd::SchemaRepository)
         expect(repository.files).to include(schema_files.first)
       end
@@ -353,7 +327,6 @@ RSpec.describe Lutaml::Xsd::SchemaRepository do
 
   describe ".from_yaml_file with base_packages" do
     it "deserializes BasePackageConfig objects from YAML" do
-      # Skip if test packages don't exist
       skip "Test packages not available" unless File.exist?("test1.lxr") && File.exist?("test2.lxr")
 
       yaml_content = <<~YAML
@@ -372,7 +345,6 @@ RSpec.describe Lutaml::Xsd::SchemaRepository do
         file.write(yaml_content)
         file.rewind
 
-        # This will fail if packages don't exist, but that's expected
         expect do
           Lutaml::Xsd::SchemaRepository.from_yaml_file(file.path)
         end.to raise_error(Lutaml::Xsd::ConfigurationError)
@@ -380,7 +352,6 @@ RSpec.describe Lutaml::Xsd::SchemaRepository do
     end
 
     it "handles all BasePackageConfig fields" do
-      # Skip if test package doesn't exist
       skip "Test package not available" unless File.exist?("test.lxr")
 
       yaml_content = <<~YAML
@@ -403,7 +374,6 @@ RSpec.describe Lutaml::Xsd::SchemaRepository do
         file.write(yaml_content)
         file.rewind
 
-        # This will fail if package doesn't exist, but that's expected
         expect do
           Lutaml::Xsd::SchemaRepository.from_yaml_file(file.path)
         end.to raise_error(Lutaml::Xsd::ConfigurationError)

--- a/spec/lutaml/xsd/type_searcher_spec.rb
+++ b/spec/lutaml/xsd/type_searcher_spec.rb
@@ -3,56 +3,37 @@
 require "spec_helper"
 
 RSpec.describe Lutaml::Xsd::TypeSearcher do
-  let(:schema_files) do
-    [
-      File.expand_path("../../fixtures/i-ur/urbanObject.xsd", __dir__),
-    ]
-  end
-
-  let(:schema_location_mappings) do
-    [
-      Lutaml::Xsd::SchemaLocationMapping.new(
-        from: '(?:\.\./)+gml/(.+\.xsd)$',
-        to: File.expand_path('../../fixtures/codesynthesis-gml-3.2.1/gml/\\1',
-                             __dir__),
-        pattern: true,
-      ),
-      Lutaml::Xsd::SchemaLocationMapping.new(
-        from: '(?:\.\./)+iso/(.+\.xsd)$',
-        to: File.expand_path('../../fixtures/codesynthesis-gml-3.2.1/iso/\\1',
-                             __dir__),
-        pattern: true,
-      ),
-      Lutaml::Xsd::SchemaLocationMapping.new(
-        from: '(?:\.\./)+xlink/(.+\.xsd)$',
-        to: File.expand_path(
-          '../../fixtures/codesynthesis-gml-3.2.1/xlink/\\1', __dir__
+  before(:context) do
+    @repository = Lutaml::Xsd::SchemaRepository.new(
+      files: [File.expand_path("../../fixtures/i-ur/urbanObject.xsd", __dir__)],
+      schema_location_mappings: [
+        Lutaml::Xsd::SchemaLocationMapping.new(
+          from: '(?:\.\./)+gml/(.+\.xsd)$',
+          to: File.expand_path('../../fixtures/codesynthesis-gml-3.2.1/gml/\1', __dir__),
+          pattern: true,
         ),
-        pattern: true,
-      ),
-    ]
-  end
-
-  let(:namespace_mappings) do
-    {
-      "gml" => "http://www.opengis.net/gml/3.2",
-      "xs" => "http://www.w3.org/2001/XMLSchema",
-      "xlink" => "http://www.w3.org/1999/xlink",
-      "uro" => "https://www.geospatial.jp/iur/uro/3.2",
-    }
-  end
-
-  let(:repository) do
-    repo = Lutaml::Xsd::SchemaRepository.new(
-      files: schema_files,
-      schema_location_mappings: schema_location_mappings,
+        Lutaml::Xsd::SchemaLocationMapping.new(
+          from: '(?:\.\./)+iso/(.+\.xsd)$',
+          to: File.expand_path('../../fixtures/codesynthesis-gml-3.2.1/iso/\1', __dir__),
+          pattern: true,
+        ),
+        Lutaml::Xsd::SchemaLocationMapping.new(
+          from: '(?:\.\./)+xlink/(.+\.xsd)$',
+          to: File.expand_path('../../fixtures/codesynthesis-gml-3.2.1/xlink/\1', __dir__),
+          pattern: true,
+        ),
+      ],
     )
-    repo.configure_namespaces(namespace_mappings)
-    repo.parse
-    repo.resolve
-    repo
+    @repository.configure_namespaces({
+                                       "gml" => "http://www.opengis.net/gml/3.2",
+                                       "xs" => "http://www.w3.org/2001/XMLSchema",
+                                       "xlink" => "http://www.w3.org/1999/xlink",
+                                       "uro" => "https://www.geospatial.jp/iur/uro/3.2",
+                                     })
+    @repository.parse.resolve
   end
 
+  let(:repository) { @repository }
   let(:searcher) { described_class.new(repository) }
 
   describe "#initialize" do
@@ -64,7 +45,6 @@ RSpec.describe Lutaml::Xsd::TypeSearcher do
   describe "#search" do
     context "when searching by name" do
       it "finds types with exact name match" do
-        # Search for a type that exists in the schema
         results = searcher.search("BuildingDetailsType", in_field: "name")
         expect(results).to be_an(Array)
 
@@ -112,7 +92,6 @@ RSpec.describe Lutaml::Xsd::TypeSearcher do
         results_upper = searcher.search("BUILDING", in_field: "name")
         results_mixed = searcher.search("Building", in_field: "name")
 
-        # Should find the same results regardless of case
         expect(results_lower.map(&:qualified_name).sort).to eq(results_upper.map(&:qualified_name).sort)
         expect(results_lower.map(&:qualified_name).sort).to eq(results_mixed.map(&:qualified_name).sort)
       end
@@ -120,11 +99,9 @@ RSpec.describe Lutaml::Xsd::TypeSearcher do
 
     context "when searching by documentation" do
       it "searches in documentation text" do
-        # NOTE: Results depend on what documentation exists in the test schemas
         results = searcher.search("building", in_field: "documentation")
         expect(results).to be_an(Array)
 
-        # Verify that all results have documentation
         results.each do |result|
           expect(result.documentation).not_to be_nil
         end
@@ -142,14 +119,12 @@ RSpec.describe Lutaml::Xsd::TypeSearcher do
         results = searcher.search("building")
         expect(results).to be_an(Array)
 
-        # Should include matches from both name and documentation
         if results.any?
           name_matches = results.select do |r|
             r.match_type.start_with?("name_")
           end
           doc_matches = results.select { |r| r.match_type.start_with?("doc_") }
 
-          # At least one type of match should exist
           expect(name_matches.any? || doc_matches.any?).to be true
         end
       end
@@ -165,7 +140,6 @@ RSpec.describe Lutaml::Xsd::TypeSearcher do
         uro_namespace = "https://www.geospatial.jp/iur/uro/3.2"
         results = searcher.search("Type", namespace: uro_namespace)
 
-        # All results should be from the specified namespace
         results.each do |result|
           expect(result.namespace).to eq(uro_namespace)
         end
@@ -181,7 +155,6 @@ RSpec.describe Lutaml::Xsd::TypeSearcher do
       it "filters results by complex_type category" do
         results = searcher.search("Type", category: "complex_type")
 
-        # All results should be complex types
         results.each do |result|
           expect(result.category).to eq(:complex_type)
         end
@@ -190,7 +163,6 @@ RSpec.describe Lutaml::Xsd::TypeSearcher do
       it "filters results by element category" do
         results = searcher.search("", category: "element", limit: 100)
 
-        # All results should be elements (if any exist)
         results.each do |result|
           expect(result.category).to eq(:element)
         end
@@ -212,12 +184,10 @@ RSpec.describe Lutaml::Xsd::TypeSearcher do
 
       it "returns all results when limit is higher than result count" do
         results = searcher.search("BuildingDetailsType", limit: 100)
-        # Should return at most a few results for this specific search
         expect(results.size).to be <= 100
       end
 
       it "uses default limit of 20" do
-        # Create a searcher and search without specifying limit
         results = searcher.search("Type")
         expect(results.size).to be <= 20
       end
@@ -252,7 +222,6 @@ RSpec.describe Lutaml::Xsd::TypeSearcher do
       it "sorts results by relevance score" do
         results = searcher.search("Type", limit: 50)
 
-        # Check that results are sorted by score (descending)
         scores = results.map(&:relevance_score)
         expect(scores).to eq(scores.sort.reverse)
       end
@@ -260,7 +229,6 @@ RSpec.describe Lutaml::Xsd::TypeSearcher do
       it "sorts by name when scores are equal" do
         results = searcher.search("building", in_field: "name", limit: 50)
 
-        # Group by score and check alphabetical ordering within each group
         results.group_by(&:relevance_score).each_value do |group|
           names = group.map(&:qualified_name)
           expect(names).to eq(names.sort)
@@ -344,7 +312,6 @@ RSpec.describe Lutaml::Xsd::TypeSearcher do
       results = searcher.search("Type", limit: 10)
 
       results.each do |result|
-        # Qualified names should use configured prefixes
         next unless result.namespace
 
         prefix = repository.namespace_to_prefix(result.namespace)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,12 @@ require "liquid"
 require "lutaml/xsd"
 require "canon"
 
+# Block network calls in tests — return nil so import resolution is gracefully
+# skipped instead of raising and killing the whole parse.
+Net::HTTP.define_singleton_method(:get) do |*_args|
+  nil
+end
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"


### PR DESCRIPTION
## Problem

The test suite took ~27 minutes to run. Profiling showed two root causes accounting for 96.8% of total time:

| Spec | Time | % of suite |
|------|------|------------|
| `TypeSearcher` | 1145s (19min) | 71.1% |
| `SchemaRepository` | 414s (7min) | 25.7% |

**Why so slow:**
- Both specs use `let(:repository)` which creates a fresh `SchemaRepository`, parsing 63+ XSD files for **every single example**. Each parse costs ~44s.
- The `urbanObject.xsd` fixture has 12 imports pointing to `schemas.opengis.net`. Each import waits for an HTTP timeout (~5-10s) on every parse.

## Changes

1. **`spec/spec_helper.rb`** — Stub `Net::HTTP.get` to return `nil`, blocking all network calls in tests. Import resolution fails fast instead of timing out. Tests should never depend on external schema availability.

2. **`spec/lutaml/xsd/type_searcher_spec.rb`** — Replace per-example `let(:repository)` with `before(:context)` + `@repository`, sharing one parsed repository across all 29 examples.

3. **`spec/lutaml/xsd/schema_repository_spec.rb`** — Wrap expensive describe blocks (`#resolve`, `#find_type`, `#validate`, `#statistics`, `#all_namespaces`) in a shared context with one `before(:context)` setup.

## Results

- **Before:** 26min 51s (1611s)
- **After:** ~31s
- **Speedup:** ~50x
- All 1352 examples pass, 0 failures, rubocop clean